### PR TITLE
Updates adapter passing to latest eliza version

### DIFF
--- a/.changeset/wise-adults-guess.md
+++ b/.changeset/wise-adults-guess.md
@@ -1,0 +1,6 @@
+---
+"@elizaos/adapter-sqlite": minor
+"@iqai/agent": minor
+---
+
+enables the withDatabase method on agent builder to take either plugin directly or adapter

--- a/apps/docs/src/content/docs/adapters/postgres.mdx
+++ b/apps/docs/src/content/docs/adapters/postgres.mdx
@@ -12,11 +12,15 @@ The **PostgreSQL Adapter** provides robust database functionality with vector se
 
 <Steps>
 1. Install required packages:
-   <PackageManagers pkg="github:elizaos-plugins/adapter-postgres pg" />
+   <PackageManagers pkg="github:elizaos-plugins/adapter-postgres" />
 
-2. Install PostgreSQL extension:
+2. Setup env variable:
    ```bash
-   CREATE EXTENSION pgvector;
+   POSTGRES_URL=postgresql://user:pass@localhost:5432/db
+   ```
+3. Enable vector search extension:
+   ```bash
+   CREATE EXTENSION vector;
    ```
 </Steps>
 
@@ -24,20 +28,10 @@ The **PostgreSQL Adapter** provides robust database functionality with vector se
 
 ```typescript
 import { AgentBuilder } from "@iqai/agent";
-import { PostgresDatabaseAdapter } from "@elizaos/adapter-postgres";
-
-const databaseAdapter = new PostgresDatabaseAdapter({
-  connectionString: "postgresql://user:pass@localhost:5432/db",
-  // or individual connection parameters
-  host: 'localhost',
-  port: 5432,
-  database: 'brain_agent',
-  user: 'postgres',
-  password: 'your_password'
-});
+import PostgresAdapter from "@elizaos/adapter-postgres";
 
 const agent = new AgentBuilder()
-  .withDatabase(databaseAdapter)
+  .withDatabase(PostgresAdapter)
   // ... other configuration
   .build();
 ```

--- a/apps/docs/src/content/docs/adapters/sqlite.mdx
+++ b/apps/docs/src/content/docs/adapters/sqlite.mdx
@@ -12,14 +12,14 @@ The **SQLite Adapter** provides embedded database functionality, ideal for devel
 
 <Steps>
 1. Install required packages:
-   <PackageManagers pkg="@iqai/adapter-sqlite" />
+   <PackageManagers pkg="github:elizaos-plugins/adapter-sqlite" />
 </Steps>
 
 ## Basic Setup
 
 ```typescript
 import { AgentBuilder } from "@iqai/agent";
-import { SqliteDatabaseAdapter } from "@iqai/adapter-sqlite";
+import SqliteAdapter from "@elizaos/adapter-sqlite";
 
 
 const databaseAdapter = new SqliteDatabaseAdapter();

--- a/apps/docs/src/content/docs/adapters/sqlite.mdx
+++ b/apps/docs/src/content/docs/adapters/sqlite.mdx
@@ -36,17 +36,6 @@ const agent = new AgentBuilder()
 - ✔️ BLOB storage support
 - ✔️ Zero setup requirements
 
-## Storage Configuration
-
-```typescript
-
-
-// Basic configuration
-const adapter = new SqliteDatabaseAdapter({
-  dbPath: "./data/db.sqlite",
-});
-```
-
 ## Collections Structure
 
 The adapter automatically manages these collections:

--- a/apps/docs/src/content/docs/clients/discord.mdx
+++ b/apps/docs/src/content/docs/clients/discord.mdx
@@ -26,16 +26,12 @@ The **Discord Client** enables your agent to interact with Discord servers, supp
 ```typescript
 import { AgentBuilder, ModelProviderName } from "@iqai/agent";
 import DiscordClient from "@elizaos/client-discord";
-import { SqliteDatabaseAdapter } from "@iqai/adapter-sqlite";
+import SqliteAdapter from "@elizaos/adapter-sqlite";
 
 
 async function main() {
-  // Initialize database adapter
-  const databaseAdapter = new SqliteDatabaseAdapter();
-
-  // Create agent with Discord client
   const agent = new AgentBuilder()
-    .withDatabase(databaseAdapter)
+    .withDatabase(SqliteAdapter)
     .withClient(DiscordClient)
     .withModelProvider(
       ModelProviderName.OPENAI,

--- a/apps/docs/src/content/docs/clients/telegram.mdx
+++ b/apps/docs/src/content/docs/clients/telegram.mdx
@@ -25,14 +25,12 @@ The **Telegram Client** enables your agent to interact through Telegram, support
 ```typescript
 import { AgentBuilder, ModelProviderName } from "@iqai/agent";
 import TelegramClient from "@elizaos/client-telegram";
-import { SqliteDatabaseAdapter } from "@iqai/adapter-sqlite";
+import SqliteAdapter from "@elizaos/adapter-sqlite";
 
 
 async function main() {
-  const databaseAdapter = new SqliteDatabaseAdapter();
-
   const agent = new AgentBuilder()
-    .withDatabase(databaseAdapter)
+    .withDatabase(SqliteAdapter)
     .withClient(TelegramClient)
     .withModelProvider(
       ModelProviderName.OPENAI,

--- a/apps/docs/src/content/docs/clients/twitter.mdx
+++ b/apps/docs/src/content/docs/clients/twitter.mdx
@@ -25,14 +25,12 @@ The **Twitter Client** enables your agent to interact through Twitter, supportin
 ```typescript
 import { AgentBuilder, ModelProviderName } from "@iqai/agent";
 import TwitterClient from "@elizaos/client-twitter";
-import { SqliteDatabaseAdapter } from "@iqai/adapter-sqlite";
+import SqliteAdapter from "@elizaos/adapter-sqlite";
 
 
 async function main() {
-  const databaseAdapter = new SqliteDatabaseAdapter();
-
   const agent = new AgentBuilder()
-    .withDatabase(databaseAdapter)
+    .withDatabase(SqliteAdapter)
     .withClient(TwitterClient)
     .withModelProvider(
       ModelProviderName.OPENAI,

--- a/apps/docs/src/content/docs/getting-started/agent-creation.mdx
+++ b/apps/docs/src/content/docs/getting-started/agent-creation.mdx
@@ -13,16 +13,14 @@ Before diving into individual configuration options, here's how all the pieces c
 
 ```typescript
 import { AgentBuilder, ModelProviderName } from "@iqai/agent";
-import { SqliteDatabaseAdapter } from "@iqai/adapter-sqlite";
+import SqliteAdapter from "@elizaos/adapter-sqlite";
 import DirectClient from "@elizaos/client-direct";
 
 
 async function main() {
-  // Setup database
-  const databaseAdapter = new SqliteDatabaseAdapter();
 
   const agent = new AgentBuilder()
-    .withDatabase(databaseAdapter)
+    .withDatabase(SqliteAdapter)
     .withClient(DirectClient)
     .withModelProvider(ModelProviderName.OPENAI, process.env.OPENAI_API_KEY)
     .withCharacter({
@@ -54,7 +52,7 @@ The database adapter provides persistence for the agent. Available options:
 <Tabs>
   <TabItem label="SQLite">
     ```typescript
-    import { SqliteDatabaseAdapter } from "@iqai/adapter-sqlite";
+    import SqliteAdapter from "@elizaos/adapter-sqlite";
 
 
     const sqliteAdapter = new SqliteDatabaseAdapter(

--- a/apps/docs/src/content/docs/getting-started/agent-creation.mdx
+++ b/apps/docs/src/content/docs/getting-started/agent-creation.mdx
@@ -18,7 +18,6 @@ import DirectClient from "@elizaos/client-direct";
 
 
 async function main() {
-
   const agent = new AgentBuilder()
     .withDatabase(SqliteAdapter)
     .withClient(DirectClient)

--- a/apps/docs/src/content/docs/getting-started/deployment.mdx
+++ b/apps/docs/src/content/docs/getting-started/deployment.mdx
@@ -25,7 +25,7 @@ Choose the appropriate database adapter based on your deployment needs:
     </Card>
 
     <Card title="SQLite" icon="document">
-      **@iqai/adapter-sqlite**
+      **@elizaos/adapter-sqlite**
       - Great for development and small deployments
       - Self-contained file database
     </Card>

--- a/apps/docs/src/content/docs/getting-started/quickstart.mdx
+++ b/apps/docs/src/content/docs/getting-started/quickstart.mdx
@@ -57,7 +57,7 @@ If you prefer to set up your project from scratch, you can follow these steps:
    ```
 
 4. Install the required Brain Framework packages:
-   <PackageManagers pkg="@iqai/agent @iqai/adapter-sqlite @elizaos/client-direct@0.25.9 sharp dotenv" />
+   <PackageManagers pkg="@iqai/agent github:elizaos-plugins/adapter-sqlite @elizaos/client-direct@0.25.9 sharp dotenv" />
 
 5. Add your OpenAI API key to the `.env` file:
    ```javascript
@@ -77,7 +77,7 @@ To create an agent, you'll need three key components:
 <Steps>
 1. Open `src/index.ts` in your favorite code editor and add the following code:
    ```javascript
-   import { SqliteDatabaseAdapter } from "@iqai/adapter-sqlite";
+   import SqliteAdapter from "@elizaos/adapter-sqlite";
    import DirectClient from "@elizaos/client-direct";
    import { AgentBuilder, ModelProviderName } from "@iqai/agent";
 
@@ -89,14 +89,10 @@ To create an agent, you'll need three key components:
    const OPENAI_API_KEY = process.env.OPENAI_API_KEY as string;
 
    async function main() {
-      const databaseAdapter = new SqliteDatabaseAdapter(
-         new Database("./data/db.sqlite"),
-      );
-
       // Create your agent with basic configuration
       const agent = new AgentBuilder()
          .withModelProvider(ModelProviderName.OPENAI, OPENAI_API_KEY)
-         .withDatabase(databaseAdapter)
+         .withDatabase(SqliteAdapter)
          .withClient(DirectClient)
          .build();
 

--- a/apps/docs/src/content/docs/getting-started/quickstart.mdx
+++ b/apps/docs/src/content/docs/getting-started/quickstart.mdx
@@ -80,18 +80,15 @@ To create an agent, you'll need three key components:
    import SqliteAdapter from "@elizaos/adapter-sqlite";
    import DirectClient from "@elizaos/client-direct";
    import { AgentBuilder, ModelProviderName } from "@iqai/agent";
-
    import dotenv from "dotenv";
 
    // Load environment variables
    dotenv.config();
 
-   const OPENAI_API_KEY = process.env.OPENAI_API_KEY as string;
-
    async function main() {
       // Create your agent with basic configuration
       const agent = new AgentBuilder()
-         .withModelProvider(ModelProviderName.OPENAI, OPENAI_API_KEY)
+         .withModelProvider(ModelProviderName.OPENAI, process.env.OPENAI_API_KEY)
          .withDatabase(SqliteAdapter)
          .withClient(DirectClient)
          .build();

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -11,14 +11,14 @@
 		"test": "jest"
 	},
 	"dependencies": {
-		"@elizaos/client-direct": "0.25.9",
-		"@elizaos/client-telegram": "github:elizaos-plugins/client-telegram",
-		"@elizaos/core": "0.25.9",
-		"@elizaos/plugin-bootstrap": "0.25.9",
-		"@iqai/adapter-sqlite": "0.0.1",
 		"@iqai/agent": "workspace:*",
 		"@iqai/plugin-atp": "workspace:*",
 		"@iqai/plugin-sequencer": "workspace:*",
+		"@elizaos/core": "0.25.9",
+		"@elizaos/plugin-bootstrap": "0.25.9",
+		"@elizaos/client-direct": "0.25.9",
+		"@elizaos/client-telegram": "github:elizaos-plugins/client-telegram",
+		"@elizaos/adapter-sqlite": "github:elizaos-plugins/adapter-sqlite",
 		"dotenv": "^16.4.7",
 		"viem": "^2.22.15"
 	},

--- a/apps/playground/src/index.ts
+++ b/apps/playground/src/index.ts
@@ -1,6 +1,6 @@
+import SqliteAdapter from "@elizaos/adapter-sqlite";
 import DirectClient from "@elizaos/client-direct";
 import TelegramClient from "@elizaos/client-telegram";
-import { SqliteDatabaseAdapter } from "@iqai/adapter-sqlite";
 import { AgentBuilder, ModelProviderName } from "@iqai/agent";
 import { createAtpPlugin } from "@iqai/plugin-atp";
 import createSequencerPlugin from "@iqai/plugin-sequencer";
@@ -12,12 +12,9 @@ async function main() {
 	});
 	const sequencerPlugin = await createSequencerPlugin();
 
-	// Setup database
-	const databaseAdapter = new SqliteDatabaseAdapter();
-
 	// Build agent using builder pattern
 	const agent = new AgentBuilder()
-		.withDatabase(databaseAdapter)
+		.withDatabase(SqliteAdapter)
 		.withClient(DirectClient)
 		.withClient(TelegramClient)
 		.withModelProvider(
@@ -25,18 +22,6 @@ async function main() {
 			process.env.OPENAI_API_KEY as string,
 		)
 		.withPlugins([atpPlugin, sequencerPlugin])
-		.withCharacter({
-			name: "BrainBot",
-			bio: "You are BrainBot, a helpful assistant.",
-			username: "brainbot",
-			messageExamples: [],
-			lore: [],
-			style: {
-				all: [],
-				chat: [],
-				post: [],
-			},
-		})
 		.build();
 
 	await agent.start();

--- a/apps/playground/src/index.ts
+++ b/apps/playground/src/index.ts
@@ -15,8 +15,7 @@ async function main() {
 	// Build agent using builder pattern
 	const agent = new AgentBuilder()
 		.withDatabase(SqliteAdapter)
-		.withClient(DirectClient)
-		.withClient(TelegramClient)
+		.withClients([DirectClient, TelegramClient])
 		.withModelProvider(
 			ModelProviderName.OPENAI,
 			process.env.OPENAI_API_KEY as string,

--- a/packages/adapter-sqlite/README.md
+++ b/packages/adapter-sqlite/README.md
@@ -7,19 +7,19 @@ A wrapper around [better-sqlite3](https://github.com/JoshuaWise/better-sqlite3) 
 Install the package using npm:
 
 ```bash
-npm install @iqai/adapter-sqlite
+npm install @elizaos/adapter-sqlite
 ```
 
 Or with yarn:
 
 ```bash
-yarn add @iqai/adapter-sqlite
+yarn add @elizaos/adapter-sqlite
 ```
 
 Or with pnpm:
 
 ```bash
-pnpm add @iqai/adapter-sqlite
+pnpm add @elizaos/adapter-sqlite
 ```
 
 ## 🚀 Usage
@@ -28,14 +28,12 @@ Basic usage:
 
 ```typescript
 import { AgentBuilder, ModelProviderName } from "@iqai/agent";
-import { SqliteDatabaseAdapter } from "@iqai/adapter-sqlite";
+import SqliteAdapter from "@elizaos/adapter-sqlite";
 
 async function main() {
-  // Setup database
-  const databaseAdapter = new SqliteDatabaseAdapter();
 
   const agent = new AgentBuilder()
-    .withDatabase(databaseAdapter)
+    .withDatabase(SqliteAdapter)
     // More options...
     .build();
 

--- a/packages/adapter-sqlite/package.json
+++ b/packages/adapter-sqlite/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@iqai/adapter-sqlite",
+	"name": "@elizaos/adapter-sqlite",
 	"version": "0.1.0",
 	"main": "dist/index.js",
 	"type": "module",

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -44,16 +44,14 @@ Basic usage with builder pattern:
 
 ```typescript
 import { AgentBuilder, ModelProviderName } from "@iqai/agent";
-import { SqliteDatabaseAdapter } from "@iqai/adapter-sqlite";
+import SqliteAdapter from "@elizaos/adapter-sqlite";
 import DirectClient from "@elizaos/client-direct";
 
 
 async function main() {
-  // Setup database
-  const databaseAdapter = new SqliteDatabaseAdapter();
 
   const agent = new AgentBuilder()
-    .withDatabase(databaseAdapter)
+    .withDatabase(SqliteAdapter)
     .withClient(DirectClient)
     .withModelProvider(ModelProviderName.OPENAI, process.env.OPENAI_API_KEY)
     .withCharacter({
@@ -84,7 +82,7 @@ Configure a database adapter for the agent.
 
 ```typescript
 // SQLite
-import { SqliteDatabaseAdapter } from "@iqai/adapter-sqlite";
+import SqliteAdapter from "@elizaos/adapter-sqlite";
 
 
 const sqliteAdapter = new SqliteDatabaseAdapter(

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -121,6 +121,15 @@ export class Agent {
 				...defaultCharacter,
 				...this.options.character,
 				modelProvider,
+				settings: {
+					...(defaultCharacter.settings || {}),
+					...(this.options.character?.settings || {}),
+					secrets: {
+						...(defaultCharacter.settings?.secrets || {}),
+						...(this.options.character?.settings?.secrets || {}),
+						...process.env,
+					},
+				},
 			},
 			fetch: async (url: string, options: RequestInit) => {
 				return fetch(url, options);

--- a/packages/agent/src/builder.ts
+++ b/packages/agent/src/builder.ts
@@ -1,9 +1,8 @@
 import type {
+	Adapter,
 	CacheStore,
 	Character,
 	Client,
-	IDatabaseAdapter,
-	IDatabaseCacheAdapter,
 	ModelProviderName,
 	Plugin,
 } from "@elizaos/core";
@@ -12,13 +11,17 @@ import { Agent, type AgentOptions } from "./agent";
 export class AgentBuilder {
 	private options: Partial<AgentOptions> = {};
 
-	public withDatabase(adapter: IDatabaseAdapter & IDatabaseCacheAdapter) {
-		this.options.databaseAdapter = adapter;
+	public withDatabase(adapter: Adapter | Plugin) {
+		if (this.isAdapterPlugin(adapter)) {
+			this.options.adapter = adapter.adapters[0];
+		} else {
+			this.options.adapter = adapter as Adapter;
+		}
 		return this;
 	}
 
 	public withClient(client: Client | Plugin) {
-		if ("clients" in client) {
+		if (this.isClientPlugin(client)) {
 			this.options.clients = [
 				...(this.options.clients || []),
 				...client.clients,
@@ -34,7 +37,7 @@ export class AgentBuilder {
 
 	public withClients(clients: (Client | Plugin)[]) {
 		const passedClients = clients?.flatMap((client) => {
-			if ("clients" in client) {
+			if (this.isClientPlugin(client)) {
 				return client.clients as Client[];
 			}
 			return client as Client;
@@ -71,9 +74,17 @@ export class AgentBuilder {
 	}
 
 	public build(): Agent {
-		if (!this.options.databaseAdapter) {
+		if (!this.options.adapter) {
 			throw new Error("Database adapter is required");
 		}
 		return new Agent(this.options as AgentOptions);
+	}
+
+	private isClientPlugin(obj: Client | Plugin): obj is Plugin {
+		return "clients" in obj;
+	}
+
+	private isAdapterPlugin(obj: Adapter | Plugin): obj is Plugin {
+		return "adapters" in obj;
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,9 @@ importers:
 
   apps/playground:
     dependencies:
+      '@elizaos/adapter-sqlite':
+        specifier: github:elizaos-plugins/adapter-sqlite
+        version: '@elizaos-plugins/adapter-sqlite@https://codeload.github.com/elizaos-plugins/adapter-sqlite/tar.gz/4331b224eb995ff39cc996a8f2bbbf62ddd8cdf1(whatwg-url@7.1.0)'
       '@elizaos/client-direct':
         specifier: 0.25.9
         version: 0.25.9(@types/debug@4.1.12)(@types/node@22.13.1)(bufferutil@4.0.9)(jiti@1.21.7)(react@19.0.0)(tsx@4.19.2)(typescript@5.7.3)(utf-8-validate@5.0.10)(whatwg-url@7.1.0)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(yaml@2.7.0)
@@ -213,9 +216,6 @@ importers:
       '@elizaos/plugin-bootstrap':
         specifier: 0.25.9
         version: 0.25.9(@types/debug@4.1.12)(@types/node@22.13.1)(bufferutil@4.0.9)(jiti@1.21.7)(react@19.0.0)(tsx@4.19.2)(typescript@5.7.3)(utf-8-validate@5.0.10)(whatwg-url@7.1.0)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(yaml@2.7.0)
-      '@iqai/adapter-sqlite':
-        specifier: 0.0.1
-        version: 0.0.1(@google-cloud/vertexai@1.9.3)(@langchain/core@0.3.38(openai@4.73.0(zod@3.23.8)))(axios@1.7.9)(react@19.0.0)(sswr@2.1.0(svelte@5.19.8))(svelte@5.19.8)(vue@3.5.13(typescript@5.7.3))(whatwg-url@7.1.0)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@iqai/agent':
         specifier: workspace:*
         version: link:../../packages/agent
@@ -230,7 +230,7 @@ importers:
         version: 16.4.7
       viem:
         specifier: ^2.22.15
-        version: 2.22.22(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.23.8)
+        version: 2.22.22(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.2)
     devDependencies:
       ts-node:
         specifier: 10.9.2
@@ -252,7 +252,7 @@ importers:
         version: 0.25.6-alpha.1(@google-cloud/vertexai@1.9.3)(@langchain/core@0.3.38(openai@4.73.0(zod@3.24.2)))(axios@1.7.9)(react@19.0.0)(whatwg-url@7.1.0)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)
       '@elizaos/core':
         specifier: 0.1.9
-        version: 0.1.9(@google-cloud/vertexai@1.9.3)(@langchain/core@0.3.38(openai@4.73.0(zod@3.24.2)))(axios@1.7.9)(react@19.0.0)(sswr@2.1.0(svelte@5.19.8))(svelte@5.19.8)(vue@3.5.13(typescript@5.7.3))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        version: 0.1.9(@google-cloud/vertexai@1.9.3)(@langchain/core@0.3.38(openai@4.73.0(zod@3.24.2)))(axios@1.7.9)(react@19.0.0)(sswr@2.2.0(svelte@5.19.8))(svelte@5.19.8)(vue@3.5.13(typescript@5.7.3))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       better-sqlite3:
         specifier: 11.8.1
         version: 11.8.1
@@ -1159,14 +1159,15 @@ packages:
   '@electric-sql/pglite@0.2.17':
     resolution: {integrity: sha512-qEpKRT2oUaWDH6tjRxLHjdzMqRUGYDnGZlKrnL4dJ77JVMcP2Hpo3NYnOSPKdZdeec57B6QPprCUFg0picx5Pw==}
 
+  '@elizaos-plugins/adapter-sqlite@https://codeload.github.com/elizaos-plugins/adapter-sqlite/tar.gz/4331b224eb995ff39cc996a8f2bbbf62ddd8cdf1':
+    resolution: {tarball: https://codeload.github.com/elizaos-plugins/adapter-sqlite/tar.gz/4331b224eb995ff39cc996a8f2bbbf62ddd8cdf1}
+    version: 0.25.6-alpha.1
+    peerDependencies:
+      whatwg-url: 7.1.0
+
   '@elizaos-plugins/client-telegram@https://codeload.github.com/elizaos-plugins/client-telegram/tar.gz/bb3a5422f18a27f222871ac8e695516ed266efec':
     resolution: {tarball: https://codeload.github.com/elizaos-plugins/client-telegram/tar.gz/bb3a5422f18a27f222871ac8e695516ed266efec}
     version: 0.25.6-alpha.1
-
-  '@elizaos/adapter-sqlite@0.1.9':
-    resolution: {integrity: sha512-r76heXuu3fcDYXyqxsSmAQ/X2KOeoZEY4BM/SPLI9aBd6xJewPC0ig6nRvAvoHBDaKgpBf3cwUvvz/MADCirCg==}
-    peerDependencies:
-      whatwg-url: 7.1.0
 
   '@elizaos/adapter-sqlite@0.25.6-alpha.1':
     resolution: {integrity: sha512-nNfM/hIYkEglYBd03pIrzOOerNLSDq/XI4yyjz8wtBNtMWLLuVOmcEPq7yInSTfA8aff3dxg6FevH6H8/ZPrnA==}
@@ -1707,10 +1708,6 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
-
-  '@iqai/adapter-sqlite@0.0.1':
-    resolution: {integrity: sha512-0Xw0HI5fgfIqbyFjnfyqwurt7nT1ux0NjCc1Wz8wYgNLvvGGSXxEbMsaG0XH0OG4rLwqp18sZTMHIeNHTgdJ5A==}
-    engines: {node: '>=22'}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -3342,9 +3339,6 @@ packages:
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
-
-  better-sqlite3@11.6.0:
-    resolution: {integrity: sha512-2J6k/eVxcFYY2SsTxsXrj6XylzHWPxveCn4fKPKZFv/Vqn/Cd7lOuX4d7rGQXT5zL+97MkNL3nSbCrIoe3LkgA==}
 
   better-sqlite3@11.8.1:
     resolution: {integrity: sha512-9BxNaBkblMjhJW8sMRZxnxVTRgbRmssZW0Oxc1MPBTfiR+WW21e2Mk4qu8CzrcZb1LwPCnFsfDEzq+SNcBU8eg==}
@@ -6588,10 +6582,10 @@ packages:
   sqlite-vec@0.1.6:
     resolution: {integrity: sha512-hQZU700TU2vWPXZYDULODjKXeMio6rKX7UpPN7Tq9qjPW671IEgURGrcC5LDBMl0q9rBvAuzmcmJmImMqVibYQ==}
 
-  sswr@2.1.0:
-    resolution: {integrity: sha512-Cqc355SYlTAaUt8iDPaC/4DPPXK925PePLMxyBKuWd5kKc5mwsG3nT9+Mq2tyguL5s7b4Jg+IRMpTRsNTAfpSQ==}
+  sswr@2.2.0:
+    resolution: {integrity: sha512-clTszLPZkmycALTHD1mXGU+mOtA/MIoLgS1KGTTzFNVm9rytQVykgRaP+z1zl572cz0bTqj4rFVoC2N+IGK4Sg==}
     peerDependencies:
-      svelte: ^4.0.0 || ^5.0.0-next.0
+      svelte: ^4.0.0 || ^5.0.0
 
   stable-hash@0.0.4:
     resolution: {integrity: sha512-LjdcbuBeLcdETCrPn9i8AYAZ1eCtu4ECAWtP7UleOiZ9LzVxRzzUZEoZ8zB24nhkQnDWyET0I+3sWokSDS3E7g==}
@@ -7841,7 +7835,7 @@ snapshots:
     dependencies:
       '@ai-sdk/provider-utils': 1.0.22(zod@3.23.8)
       '@ai-sdk/ui-utils': 0.0.50(zod@3.23.8)
-      sswr: 2.1.0(svelte@5.19.8)
+      sswr: 2.2.0(svelte@5.19.8)
     optionalDependencies:
       svelte: 5.19.8
     transitivePeerDependencies:
@@ -8637,6 +8631,13 @@ snapshots:
 
   '@electric-sql/pglite@0.2.17': {}
 
+  '@elizaos-plugins/adapter-sqlite@https://codeload.github.com/elizaos-plugins/adapter-sqlite/tar.gz/4331b224eb995ff39cc996a8f2bbbf62ddd8cdf1(whatwg-url@7.1.0)':
+    dependencies:
+      '@types/better-sqlite3': 7.6.12
+      better-sqlite3: 11.8.1
+      sqlite-vec: 0.1.6
+      whatwg-url: 7.1.0
+
   '@elizaos-plugins/client-telegram@https://codeload.github.com/elizaos-plugins/client-telegram/tar.gz/bb3a5422f18a27f222871ac8e695516ed266efec':
     dependencies:
       '@telegraf/types': 7.1.0
@@ -8644,39 +8645,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
-
-  '@elizaos/adapter-sqlite@0.1.9(@google-cloud/vertexai@1.9.3)(@langchain/core@0.3.38(openai@4.73.0(zod@3.23.8)))(axios@1.7.9)(react@19.0.0)(sswr@2.1.0(svelte@5.19.8))(svelte@5.19.8)(vue@3.5.13(typescript@5.7.3))(whatwg-url@7.1.0)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@elizaos/core': 0.1.9(@google-cloud/vertexai@1.9.3)(@langchain/core@0.3.38(openai@4.73.0(zod@3.23.8)))(axios@1.7.9)(react@19.0.0)(sswr@2.1.0(svelte@5.19.8))(svelte@5.19.8)(vue@3.5.13(typescript@5.7.3))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@types/better-sqlite3': 7.6.12
-      better-sqlite3: 11.6.0
-      sqlite-vec: 0.1.6
-      whatwg-url: 7.1.0
-    transitivePeerDependencies:
-      - '@google-cloud/vertexai'
-      - '@langchain/anthropic'
-      - '@langchain/aws'
-      - '@langchain/cohere'
-      - '@langchain/core'
-      - '@langchain/google-genai'
-      - '@langchain/google-vertexai'
-      - '@langchain/groq'
-      - '@langchain/mistralai'
-      - '@langchain/ollama'
-      - aws-crt
-      - axios
-      - cheerio
-      - debug
-      - encoding
-      - peggy
-      - react
-      - solid-js
-      - sswr
-      - supports-color
-      - svelte
-      - typeorm
-      - vue
-      - ws
 
   '@elizaos/adapter-sqlite@0.25.6-alpha.1(@google-cloud/vertexai@1.9.3)(@langchain/core@0.3.38(openai@4.73.0(zod@3.24.2)))(axios@1.7.9)(react@19.0.0)(whatwg-url@7.1.0)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)':
     dependencies:
@@ -8749,7 +8717,7 @@ snapshots:
       - ws
       - yaml
 
-  '@elizaos/core@0.1.9(@google-cloud/vertexai@1.9.3)(@langchain/core@0.3.38(openai@4.73.0(zod@3.23.8)))(axios@1.7.9)(react@19.0.0)(sswr@2.1.0(svelte@5.19.8))(svelte@5.19.8)(vue@3.5.13(typescript@5.7.3))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@elizaos/core@0.1.9(@google-cloud/vertexai@1.9.3)(@langchain/core@0.3.38(openai@4.73.0(zod@3.24.2)))(axios@1.7.9)(react@19.0.0)(sswr@2.2.0(svelte@5.19.8))(svelte@5.19.8)(vue@3.5.13(typescript@5.7.3))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@ai-sdk/amazon-bedrock': 1.1.0(zod@3.23.8)
       '@ai-sdk/anthropic': 0.0.56(zod@3.23.8)
@@ -8761,65 +8729,7 @@ snapshots:
       '@fal-ai/client': 1.2.0
       '@tavily/core': 0.0.2
       '@types/uuid': 10.0.0
-      ai: 3.4.33(openai@4.73.0(zod@3.23.8))(react@19.0.0)(sswr@2.1.0(svelte@5.19.8))(svelte@5.19.8)(vue@3.5.13(typescript@5.7.3))(zod@3.23.8)
-      anthropic-vertex-ai: 1.0.2(zod@3.23.8)
-      dotenv: 16.4.5
-      fastembed: 1.14.1
-      fastestsmallesttextencoderdecoder: 1.0.22
-      gaxios: 6.7.1
-      glob: 11.0.0
-      handlebars: 4.7.8
-      js-sha1: 0.7.0
-      js-tiktoken: 1.0.15
-      langchain: 0.3.6(@langchain/core@0.3.38(openai@4.73.0(zod@3.23.8)))(axios@1.7.9)(handlebars@4.7.8)(openai@4.73.0(zod@3.23.8))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      ollama-ai-provider: 0.16.1(zod@3.23.8)
-      openai: 4.73.0(zod@3.23.8)
-      pino: 9.6.0
-      pino-pretty: 13.0.0
-      tinyld: 1.3.4
-      together-ai: 0.7.0
-      unique-names-generator: 4.7.1
-      uuid: 11.0.3
-      zod: 3.23.8
-    transitivePeerDependencies:
-      - '@google-cloud/vertexai'
-      - '@langchain/anthropic'
-      - '@langchain/aws'
-      - '@langchain/cohere'
-      - '@langchain/core'
-      - '@langchain/google-genai'
-      - '@langchain/google-vertexai'
-      - '@langchain/groq'
-      - '@langchain/mistralai'
-      - '@langchain/ollama'
-      - aws-crt
-      - axios
-      - cheerio
-      - debug
-      - encoding
-      - peggy
-      - react
-      - solid-js
-      - sswr
-      - supports-color
-      - svelte
-      - typeorm
-      - vue
-      - ws
-
-  '@elizaos/core@0.1.9(@google-cloud/vertexai@1.9.3)(@langchain/core@0.3.38(openai@4.73.0(zod@3.24.2)))(axios@1.7.9)(react@19.0.0)(sswr@2.1.0(svelte@5.19.8))(svelte@5.19.8)(vue@3.5.13(typescript@5.7.3))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@ai-sdk/amazon-bedrock': 1.1.0(zod@3.23.8)
-      '@ai-sdk/anthropic': 0.0.56(zod@3.23.8)
-      '@ai-sdk/google': 0.0.55(zod@3.23.8)
-      '@ai-sdk/google-vertex': 0.0.43(@google-cloud/vertexai@1.9.3)(zod@3.23.8)
-      '@ai-sdk/groq': 0.0.3(zod@3.23.8)
-      '@ai-sdk/mistral': 1.0.9(zod@3.23.8)
-      '@ai-sdk/openai': 1.0.5(zod@3.23.8)
-      '@fal-ai/client': 1.2.0
-      '@tavily/core': 0.0.2
-      '@types/uuid': 10.0.0
-      ai: 3.4.33(openai@4.73.0(zod@3.23.8))(react@19.0.0)(sswr@2.1.0(svelte@5.19.8))(svelte@5.19.8)(vue@3.5.13(typescript@5.7.3))(zod@3.23.8)
+      ai: 3.4.33(openai@4.73.0(zod@3.23.8))(react@19.0.0)(sswr@2.2.0(svelte@5.19.8))(svelte@5.19.8)(vue@3.5.13(typescript@5.7.3))(zod@3.23.8)
       anthropic-vertex-ai: 1.0.2(zod@3.23.8)
       dotenv: 16.4.5
       fastembed: 1.14.1
@@ -9365,41 +9275,6 @@ snapshots:
   '@img/sharp-win32-x64@0.33.5':
     optional: true
 
-  '@iqai/adapter-sqlite@0.0.1(@google-cloud/vertexai@1.9.3)(@langchain/core@0.3.38(openai@4.73.0(zod@3.23.8)))(axios@1.7.9)(react@19.0.0)(sswr@2.1.0(svelte@5.19.8))(svelte@5.19.8)(vue@3.5.13(typescript@5.7.3))(whatwg-url@7.1.0)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@elizaos/adapter-sqlite': 0.1.9(@google-cloud/vertexai@1.9.3)(@langchain/core@0.3.38(openai@4.73.0(zod@3.23.8)))(axios@1.7.9)(react@19.0.0)(sswr@2.1.0(svelte@5.19.8))(svelte@5.19.8)(vue@3.5.13(typescript@5.7.3))(whatwg-url@7.1.0)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@elizaos/core': 0.1.9(@google-cloud/vertexai@1.9.3)(@langchain/core@0.3.38(openai@4.73.0(zod@3.23.8)))(axios@1.7.9)(react@19.0.0)(sswr@2.1.0(svelte@5.19.8))(svelte@5.19.8)(vue@3.5.13(typescript@5.7.3))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      better-sqlite3: 11.8.1
-      dedent: 1.5.3
-      zod: 3.24.2
-    transitivePeerDependencies:
-      - '@google-cloud/vertexai'
-      - '@langchain/anthropic'
-      - '@langchain/aws'
-      - '@langchain/cohere'
-      - '@langchain/core'
-      - '@langchain/google-genai'
-      - '@langchain/google-vertexai'
-      - '@langchain/groq'
-      - '@langchain/mistralai'
-      - '@langchain/ollama'
-      - aws-crt
-      - axios
-      - babel-plugin-macros
-      - cheerio
-      - debug
-      - encoding
-      - peggy
-      - react
-      - solid-js
-      - sswr
-      - supports-color
-      - svelte
-      - typeorm
-      - vue
-      - whatwg-url
-      - ws
-
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -9435,23 +9310,6 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@langchain/core@0.3.38(openai@4.73.0(zod@3.23.8))':
-    dependencies:
-      '@cfworker/json-schema': 4.1.1
-      ansi-styles: 5.2.0
-      camelcase: 6.3.0
-      decamelize: 1.2.0
-      js-tiktoken: 1.0.18
-      langsmith: 0.3.6(openai@4.73.0(zod@3.23.8))
-      mustache: 4.2.0
-      p-queue: 6.6.2
-      p-retry: 4.6.2
-      uuid: 10.0.0
-      zod: 3.24.2
-      zod-to-json-schema: 3.24.1(zod@3.24.2)
-    transitivePeerDependencies:
-      - openai
-
   '@langchain/core@0.3.38(openai@4.73.0(zod@3.24.2))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
@@ -9486,17 +9344,6 @@ snapshots:
     transitivePeerDependencies:
       - openai
 
-  '@langchain/openai@0.3.17(@langchain/core@0.3.38(openai@4.73.0(zod@3.23.8)))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@langchain/core': 0.3.38(openai@4.73.0(zod@3.23.8))
-      js-tiktoken: 1.0.18
-      openai: 4.83.0(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)
-      zod: 3.24.2
-      zod-to-json-schema: 3.24.1(zod@3.24.2)
-    transitivePeerDependencies:
-      - encoding
-      - ws
-
   '@langchain/openai@0.3.17(@langchain/core@0.3.38(openai@4.73.0(zod@3.24.2)))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@langchain/core': 0.3.38(openai@4.73.0(zod@3.24.2))
@@ -9507,11 +9354,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - ws
-
-  '@langchain/textsplitters@0.1.0(@langchain/core@0.3.38(openai@4.73.0(zod@3.23.8)))':
-    dependencies:
-      '@langchain/core': 0.3.38(openai@4.73.0(zod@3.23.8))
-      js-tiktoken: 1.0.18
 
   '@langchain/textsplitters@0.1.0(@langchain/core@0.3.38(openai@4.73.0(zod@3.24.2)))':
     dependencies:
@@ -10993,11 +10835,6 @@ snapshots:
       typescript: 5.7.3
       zod: 3.24.2
 
-  abitype@1.0.8(typescript@5.7.3)(zod@3.23.8):
-    optionalDependencies:
-      typescript: 5.7.3
-      zod: 3.23.8
-
   abitype@1.0.8(typescript@5.7.3)(zod@3.24.2):
     optionalDependencies:
       typescript: 5.7.3
@@ -11038,7 +10875,7 @@ snapshots:
     dependencies:
       humanize-ms: 1.2.1
 
-  ai@3.4.33(openai@4.73.0(zod@3.23.8))(react@19.0.0)(sswr@2.1.0(svelte@5.19.8))(svelte@5.19.8)(vue@3.5.13(typescript@5.7.3))(zod@3.23.8):
+  ai@3.4.33(openai@4.73.0(zod@3.23.8))(react@19.0.0)(sswr@2.2.0(svelte@5.19.8))(svelte@5.19.8)(vue@3.5.13(typescript@5.7.3))(zod@3.23.8):
     dependencies:
       '@ai-sdk/provider': 0.0.26
       '@ai-sdk/provider-utils': 1.0.22(zod@3.23.8)
@@ -11056,7 +10893,7 @@ snapshots:
     optionalDependencies:
       openai: 4.73.0(zod@3.24.2)
       react: 19.0.0
-      sswr: 2.1.0(svelte@5.19.8)
+      sswr: 2.2.0(svelte@5.19.8)
       svelte: 5.19.8
       zod: 3.23.8
     transitivePeerDependencies:
@@ -11430,11 +11267,6 @@ snapshots:
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
-
-  better-sqlite3@11.6.0:
-    dependencies:
-      bindings: 1.5.0
-      prebuild-install: 7.1.3
 
   better-sqlite3@11.8.1:
     dependencies:
@@ -13475,29 +13307,6 @@ snapshots:
 
   kleur@4.1.5: {}
 
-  langchain@0.3.6(@langchain/core@0.3.38(openai@4.73.0(zod@3.23.8)))(axios@1.7.9)(handlebars@4.7.8)(openai@4.73.0(zod@3.23.8))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
-    dependencies:
-      '@langchain/core': 0.3.38(openai@4.73.0(zod@3.23.8))
-      '@langchain/openai': 0.3.17(@langchain/core@0.3.38(openai@4.73.0(zod@3.23.8)))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@langchain/textsplitters': 0.1.0(@langchain/core@0.3.38(openai@4.73.0(zod@3.23.8)))
-      js-tiktoken: 1.0.18
-      js-yaml: 4.1.0
-      jsonpointer: 5.0.1
-      langsmith: 0.2.15(openai@4.73.0(zod@3.23.8))
-      openapi-types: 12.1.3
-      p-retry: 4.6.2
-      uuid: 10.0.0
-      yaml: 2.7.0
-      zod: 3.24.2
-      zod-to-json-schema: 3.24.1(zod@3.24.2)
-    optionalDependencies:
-      axios: 1.7.9
-      handlebars: 4.7.8
-    transitivePeerDependencies:
-      - encoding
-      - openai
-      - ws
-
   langchain@0.3.6(@langchain/core@0.3.38(openai@4.73.0(zod@3.24.2)))(axios@1.7.9)(handlebars@4.7.8)(openai@4.73.0(zod@3.23.8))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
     dependencies:
       '@langchain/core': 0.3.38(openai@4.73.0(zod@3.24.2))
@@ -13565,18 +13374,6 @@ snapshots:
       uuid: 10.0.0
     optionalDependencies:
       openai: 4.82.0(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)
-
-  langsmith@0.3.6(openai@4.73.0(zod@3.23.8)):
-    dependencies:
-      '@types/uuid': 10.0.0
-      chalk: 4.1.2
-      console-table-printer: 2.12.1
-      p-queue: 6.6.2
-      p-retry: 4.6.2
-      semver: 7.7.1
-      uuid: 10.0.0
-    optionalDependencies:
-      openai: 4.73.0(zod@3.23.8)
 
   langsmith@0.3.6(openai@4.73.0(zod@3.24.2)):
     dependencies:
@@ -14489,20 +14286,6 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@4.73.0(zod@3.23.8):
-    dependencies:
-      '@types/node': 18.19.75
-      '@types/node-fetch': 2.6.12
-      abort-controller: 3.0.0
-      agentkeepalive: 4.6.0
-      form-data-encoder: 1.7.2
-      formdata-node: 4.4.1
-      node-fetch: 2.7.0
-    optionalDependencies:
-      zod: 3.23.8
-    transitivePeerDependencies:
-      - encoding
-
   openai@4.73.0(zod@3.24.2):
     dependencies:
       '@types/node': 18.19.75
@@ -14576,20 +14359,6 @@ snapshots:
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
       abitype: 1.0.8(typescript@5.7.3)(zod@3.24.2)
-      eventemitter3: 5.0.1
-    optionalDependencies:
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - zod
-
-  ox@0.6.7(typescript@5.7.3)(zod@3.23.8):
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.0
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
-      '@scure/bip32': 1.6.2
-      '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.7.3)(zod@3.23.8)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.7.3
@@ -15614,7 +15383,7 @@ snapshots:
       sqlite-vec-linux-x64: 0.1.6
       sqlite-vec-windows-x64: 0.1.6
 
-  sswr@2.1.0(svelte@5.19.8):
+  sswr@2.2.0(svelte@5.19.8):
     dependencies:
       svelte: 5.19.8
       swrev: 4.0.0
@@ -16346,23 +16115,6 @@ snapshots:
       isows: 1.0.6(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       ox: 0.4.4(typescript@5.7.3)(zod@3.24.2)
       webauthn-p256: 0.0.10
-      ws: 8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-    optionalDependencies:
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-
-  viem@2.22.22(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.23.8):
-    dependencies:
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
-      '@scure/bip32': 1.6.2
-      '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.7.3)(zod@3.23.8)
-      isows: 1.0.6(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      ox: 0.6.7(typescript@5.7.3)(zod@3.23.8)
       ws: 8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.7.3


### PR DESCRIPTION
# Changes
Now eliza is exposing database adapters as plugins. Hence, this pr enables the `withDatabase` method on agent builder to take either plugin directly or adapter. This would also deprecate the use of our new sqlite adapter 😅 cuz now the sqlite adapter from eliza is initializing the db and having better-sqlite3 dependency with in itself.