### PR TITLE
Add onlyFinalOutput and formatResponse options to Heartbeat plugin

### DIFF
--- a/packages/plugin-heartbeat/src/services/heartbeat.ts
+++ b/packages/plugin-heartbeat/src/services/heartbeat.ts
@@ -159,10 +159,12 @@ export class Heartbeat extends Service {
 			return;
 		}
 
-		// Apply format function if provided
-		const formattedContent = task.formatResponse
-			? task.formatResponse(responseContent)
-			: responseContent;
+		let formattedContent: string;
+		if (task.formatResponse) {
+			formattedContent = await task.formatResponse(responseContent, runtime);
+		} else {
+			formattedContent = responseContent;
+		}
 
 		switch (task.client) {
 			case "twitter": {

--- a/packages/plugin-heartbeat/src/services/heartbeat.ts
+++ b/packages/plugin-heartbeat/src/services/heartbeat.ts
@@ -96,12 +96,16 @@ export class Heartbeat extends Service {
 
 		if (response) {
 			elizaLogger.info("📤 Heartbeat response generated:", response);
-			await this.handleSocialPost(
-				runtime,
-				heartbeatTask,
-				response.text,
-				roomId,
-			);
+
+			// Only send the initial response if we're not waiting for final output
+			if (!heartbeatTask.onlyFinalOutput) {
+				await this.handleSocialPost(
+					runtime,
+					heartbeatTask,
+					response.text,
+					roomId,
+				);
+			}
 
 			const responseMessage: Memory = {
 				id: stringToUuid(`${messageId}-${runtime.agentId}`),
@@ -124,13 +128,15 @@ export class Heartbeat extends Service {
 				[responseMessage],
 				state,
 				async (ctx) => {
-					if (ctx.text)
+					if (ctx.text) {
+						// If we're using onlyFinalOutput, this is where we send the message
 						await this.handleSocialPost(
 							runtime,
 							heartbeatTask,
 							ctx.text,
 							roomId,
 						);
+					}
 					return [memory];
 				},
 			);
@@ -153,14 +159,19 @@ export class Heartbeat extends Service {
 			return;
 		}
 
+		// Apply format function if provided
+		const formattedContent = task.formatResponse
+			? task.formatResponse(responseContent)
+			: responseContent;
+
 		switch (task.client) {
 			case "twitter": {
 				await client.post.postTweet(
 					runtime,
 					client.post.client,
-					responseContent,
+					formattedContent,
 					roomId,
-					responseContent,
+					formattedContent,
 					client.post.twitterUsername,
 				);
 				break;
@@ -168,13 +179,13 @@ export class Heartbeat extends Service {
 			case "telegram": {
 				await client.messageManager.bot.telegram.sendMessage(
 					task.config.chatId,
-					responseContent,
+					formattedContent,
 				);
 				break;
 			}
 			case "callback": {
 				try {
-					await task.config.callback(responseContent, roomId);
+					await task.config.callback(formattedContent, roomId);
 				} catch (error) {
 					elizaLogger.error(`❌ Failed to send callback: ${error}`);
 				}

--- a/packages/plugin-heartbeat/src/types.ts
+++ b/packages/plugin-heartbeat/src/types.ts
@@ -1,8 +1,13 @@
+import type { IAgentRuntime } from "@elizaos/core";
+
 export interface BaseHeartbeatTask {
 	period: string;
 	input: string;
 	onlyFinalOutput?: boolean;
-	formatResponse?: (response: string) => string;
+	formatResponse?: (
+		response: string,
+		runtime: IAgentRuntime,
+	) => Promise<string>;
 }
 
 export interface TwitterHeartbeatTask extends BaseHeartbeatTask {

--- a/packages/plugin-heartbeat/src/types.ts
+++ b/packages/plugin-heartbeat/src/types.ts
@@ -1,6 +1,8 @@
 export interface BaseHeartbeatTask {
 	period: string;
 	input: string;
+	onlyFinalOutput?: boolean;
+	formatResponse?: (response: string) => string;
 }
 
 export interface TwitterHeartbeatTask extends BaseHeartbeatTask {


### PR DESCRIPTION
# Changes
- Added two new optional properties to the BaseHeartbeatTask interface
- Modified the handleCron method to conditionally send initial responses based on the onlyFinalOutput flag
- Updated the handleSocialPost method to apply the formatResponse function when provided