### PR TITLE
patch/plugin-mcp: Update action handling

### DIFF
--- a/.changeset/gold-cows-type.md
+++ b/.changeset/gold-cows-type.md
@@ -1,0 +1,5 @@
+---
+"@iqai/plugin-mcp": patch
+---
+
+Updated action creation method to include optional config options

--- a/apps/docs/src/content/docs/plugins/mcp.mdx
+++ b/apps/docs/src/content/docs/plugins/mcp.mdx
@@ -32,6 +32,9 @@ Configure the plugin with the following parameters:
 | `name`          | Name of the MCP plugin                               | Yes          |
 | `description`   | Description of the plugin                            | Yes          |
 | `transport`     | Transport configuration object (see below)           | Yes          |
+| `handleResponse` | Custom handler for processing tool call results | No |
+| `disableToolChaining` | Disable automatic tool chaining behavior | No |
+| `toolChainingTemplate` | Custom template for tool chaining prompts | No |
 
 ### Transport Configuration
 

--- a/packages/plugin-mcp/README.md
+++ b/packages/plugin-mcp/README.md
@@ -34,6 +34,9 @@ Configure the plugin with the following parameters:
 | `name`            | Name of the MCP plugin                                       | Yes      | -       |
 | `description`     | Description of the plugin                                    | Yes      | -       |
 | `transport`       | Transport configuration object (see below)                   | Yes      | -       |
+| `handleResponse`  | Custom handler for processing tool call results              | No       | -       |
+| `disableToolChaining` | Disable automatic tool chaining                         | No       | false   |
+| `toolChainingTemplate` | Custom template for tool chaining                      | No       | -       |
 
 ### Transport Configuration
 

--- a/packages/plugin-mcp/src/index.ts
+++ b/packages/plugin-mcp/src/index.ts
@@ -26,7 +26,7 @@ export async function createMcpPlugin(
 		const actions: Action[] = [];
 
 		for (const tool of toolsResponse.tools) {
-			const action: Action = await createAction(tool, client);
+			const action: Action = await createAction(tool, client, config);
 			actions.push(action);
 		}
 

--- a/packages/plugin-mcp/src/types.ts
+++ b/packages/plugin-mcp/src/types.ts
@@ -1,7 +1,18 @@
+import type { IAgentRuntime, Memory, State } from "@elizaos/core";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
 export type McpPluginConfig = {
 	name: string;
 	description: string;
 	transport: McpTransportType;
+	handleResponse?: (
+		result: CallToolResult,
+		runtime: IAgentRuntime,
+		state: State,
+		memory: Memory,
+	) => Promise<string>;
+	disableToolChaining?: boolean;
+	toolChainingTemplate?: string;
 };
 
 export type McpTransportType =


### PR DESCRIPTION
## changes

- Updated action creation method to include these optional config params:

    ```
   	handleResponse?: (
		result: CallToolResult,
		runtime: IAgentRuntime,
		state: State,
		memory: Memory,
	) => Promise<string>;
	disableToolChaining?: boolean;
	toolChainingTemplate?: string;
	```
	