### PR TITLE
plugin-atp: add dev environment support

### DIFF
--- a/.changeset/orange-pianos-warn.md
+++ b/.changeset/orange-pianos-warn.md
@@ -1,0 +1,5 @@
+---
+"@iqai/plugin-atp": patch
+---
+
+Added dev env support

--- a/packages/plugin-atp/src/constants.ts
+++ b/packages/plugin-atp/src/constants.ts
@@ -1,11 +1,22 @@
 export const API_URLS = {
-	BASE: "https://app.iqai.com/api",
 	AGENTS_STATS: "https://app.iqai.com/api/agents/stats",
 	HOLDINGS: "https://app.iqai.com/api/holdings",
 	AGENTS: "https://app.iqai.com/api/agents/top",
 	LOGS: "https://app.iqai.com/api/logs",
 } as const;
 
+export const DEV_API_URLS = {
+	AGENTS_STATS: "https://dev.iqai.com/api/agents/stats",
+	HOLDINGS: "https://dev.iqai.com/api/holdings",
+	AGENTS: "https://dev.iqai.com/api/agents/top",
+	LOGS: "https://dev.iqai.com/api/logs",
+} as const;
+
 export const AGENT_ROUTER_ADDRESS =
 	"0xb1460781f019548d81ced6eac239025c05dc92a7";
 export const BASE_TOKEN_ADDRESS = "0x6efb84bda519726fa1c65558e520b92b51712101";
+
+export const DEV_AGENT_ROUTER_ADDRESS =
+	"0x981c84e6e1b7a27f99c62881ef3ba507f772b8c7";
+export const DEV_BASE_TOKEN_ADDRESS =
+	"0xcc3023635df54fc0e43f47bc4beb90c3d1fbda9f";

--- a/packages/plugin-atp/src/lib/router.abi.dev.ts
+++ b/packages/plugin-atp/src/lib/router.abi.dev.ts
@@ -1,0 +1,93 @@
+export const DEV_ROUTER_ABI = [
+	{
+		inputs: [
+			{
+				internalType: "contract AgentFactory",
+				name: "_factory",
+				type: "address",
+			},
+		],
+		stateMutability: "nonpayable",
+		type: "constructor",
+	},
+	{ inputs: [], name: "AgentNotFound", type: "error" },
+	{ inputs: [], name: "NoCurrencyToken", type: "error" },
+	{
+		inputs: [
+			{ internalType: "address", name: "_agentToken", type: "address" },
+			{ internalType: "uint256", name: "_amountIn", type: "uint256" },
+		],
+		name: "buy",
+		outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+		stateMutability: "nonpayable",
+		type: "function",
+	},
+	{
+		inputs: [
+			{ internalType: "address", name: "_agentToken", type: "address" },
+			{ internalType: "uint256", name: "_amountIn", type: "uint256" },
+			{ internalType: "address", name: "_recipient", type: "address" },
+		],
+		name: "buy",
+		outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+		stateMutability: "nonpayable",
+		type: "function",
+	},
+	{
+		inputs: [],
+		name: "currencyToken",
+		outputs: [{ internalType: "contract IERC20", name: "", type: "address" }],
+		stateMutability: "view",
+		type: "function",
+	},
+	{
+		inputs: [],
+		name: "factory",
+		outputs: [
+			{ internalType: "contract AgentFactory", name: "", type: "address" },
+		],
+		stateMutability: "view",
+		type: "function",
+	},
+	{
+		inputs: [],
+		name: "fraxswapFactory",
+		outputs: [
+			{ internalType: "contract IFraxswapFactory", name: "", type: "address" },
+		],
+		stateMutability: "view",
+		type: "function",
+	},
+	{
+		inputs: [
+			{ internalType: "address", name: "_tokenIn", type: "address" },
+			{ internalType: "address", name: "_tokenOut", type: "address" },
+			{ internalType: "uint256", name: "_amountIn", type: "uint256" },
+		],
+		name: "getAmountOut",
+		outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+		stateMutability: "view",
+		type: "function",
+	},
+	{
+		inputs: [
+			{ internalType: "address", name: "_agentToken", type: "address" },
+			{ internalType: "uint256", name: "_amountIn", type: "uint256" },
+			{ internalType: "address", name: "_recipient", type: "address" },
+		],
+		name: "sell",
+		outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+		stateMutability: "nonpayable",
+		type: "function",
+	},
+	{
+		inputs: [
+			{ internalType: "address", name: "_agentToken", type: "address" },
+			{ internalType: "uint256", name: "_amountIn", type: "uint256" },
+		],
+		name: "sell",
+		outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+		stateMutability: "nonpayable",
+		type: "function",
+	},
+] as const;

--- a/packages/plugin-atp/src/services/agent-logs.ts
+++ b/packages/plugin-atp/src/services/agent-logs.ts
@@ -1,4 +1,4 @@
-import { API_URLS } from "../constants";
+import { API_URLS, DEV_API_URLS } from "../constants";
 
 export enum LogType {
 	Developer = "Developer",
@@ -46,15 +46,16 @@ export class AgentLogsService {
 		limit = DEFAULT_LIMIT,
 	}: GetLogsParams): Promise<GetLogsResponse> {
 		try {
+			const endPoint = process.env.ATP_USE_DEV
+				? DEV_API_URLS.LOGS
+				: API_URLS.LOGS;
 			const queryParams = new URLSearchParams({
 				agentTokenContract,
 				page: page.toString(),
 				limit: limit.toString(),
 			});
 
-			const response = await fetch(
-				`${API_URLS.LOGS}?${queryParams.toString()}`,
-			);
+			const response = await fetch(`${endPoint}?${queryParams.toString()}`);
 
 			if (!response.ok) {
 				throw new Error(`API request failed with status ${response.status}`);
@@ -73,7 +74,10 @@ export class AgentLogsService {
 		txHash,
 	}: PostLogParams): Promise<LogEntry> {
 		try {
-			const response = await fetch(API_URLS.LOGS, {
+			const endPoint = process.env.ATP_USE_DEV
+				? DEV_API_URLS.LOGS
+				: API_URLS.LOGS;
+			const response = await fetch(endPoint, {
 				method: "POST",
 				headers: {
 					apiKey,
@@ -96,7 +100,6 @@ export class AgentLogsService {
 			throw new Error(`Failed to add agent log: ${error.message}`);
 		}
 	}
-
 	formatLogs(data: GetLogsResponse): string {
 		if (!data.logs.length) {
 			return "No logs found for this agent.";

--- a/packages/plugin-atp/src/services/agent-positions.ts
+++ b/packages/plugin-atp/src/services/agent-positions.ts
@@ -1,5 +1,5 @@
 import dedent from "dedent";
-import { API_URLS } from "../constants";
+import { API_URLS, DEV_API_URLS } from "../constants";
 import formatNumber from "../lib/format-number";
 import type { AgentPositionsResponse } from "../types";
 import type { WalletService } from "./wallet";
@@ -15,7 +15,9 @@ export class AgentPositionsService {
 		const walletClient = this.walletService.getWalletClient();
 		const userAddress = walletClient.account.address;
 		try {
-			const url = new URL(API_URLS.HOLDINGS);
+			const url = new URL(
+				process.env.ATP_USE_DEV ? DEV_API_URLS.HOLDINGS : API_URLS.HOLDINGS,
+			);
 			url.searchParams.append("address", userAddress);
 
 			const response = await fetch(url.toString(), {

--- a/packages/plugin-atp/src/services/agent-stats.ts
+++ b/packages/plugin-atp/src/services/agent-stats.ts
@@ -1,13 +1,17 @@
 import { elizaLogger } from "@elizaos/core";
 import dedent from "dedent";
-import { API_URLS } from "../constants";
+import { API_URLS, DEV_API_URLS } from "../constants";
 import formatNumber from "../lib/format-number";
 import type { AgentStats } from "../types";
 
 export class AgentStatsService {
 	async getStats(agentAddress: string): Promise<AgentStats> {
 		try {
-			const url = new URL(API_URLS.AGENTS_STATS);
+			const url = new URL(
+				process.env.ATP_USE_DEV
+					? DEV_API_URLS.AGENTS_STATS
+					: API_URLS.AGENTS_STATS,
+			);
 			url.searchParams.append("address", agentAddress);
 			elizaLogger.info("🔍 Fetching agent stats", { url });
 

--- a/packages/plugin-atp/src/services/get-agents.ts
+++ b/packages/plugin-atp/src/services/get-agents.ts
@@ -1,6 +1,6 @@
 import { elizaLogger } from "@elizaos/core";
 import dedent from "dedent";
-import { API_URLS } from "../constants";
+import { API_URLS, DEV_API_URLS } from "../constants";
 import formatNumber from "../lib/format-number";
 import type { Agent } from "../types";
 
@@ -12,7 +12,9 @@ export interface GetAgentsParams {
 export class GetAgentsService {
 	async getAgents(params: GetAgentsParams): Promise<Agent[]> {
 		try {
-			const url = new URL(API_URLS.AGENTS);
+			const url = new URL(
+				process.env.ATP_USE_DEV ? DEV_API_URLS.AGENTS : API_URLS.AGENTS,
+			);
 			if (params.sort) url.searchParams.append("sort", params.sort);
 			if (params.limit)
 				url.searchParams.append("limit", params.limit.toString());

--- a/packages/plugin-atp/src/services/swap.ts
+++ b/packages/plugin-atp/src/services/swap.ts
@@ -1,18 +1,30 @@
 import { type Address, erc20Abi } from "viem";
 import { fraxtal } from "viem/chains";
-import { AGENT_ROUTER_ADDRESS, BASE_TOKEN_ADDRESS } from "../constants";
+import {
+	AGENT_ROUTER_ADDRESS,
+	BASE_TOKEN_ADDRESS,
+	DEV_AGENT_ROUTER_ADDRESS,
+	DEV_BASE_TOKEN_ADDRESS,
+} from "../constants";
 import { ROUTER_ABI } from "../lib/router.abi";
+import { DEV_ROUTER_ABI } from "../lib/router.abi.dev";
 import type { WalletService } from "./wallet";
 
 export class SwapService {
 	private walletService: WalletService;
 	private routerAddress: Address;
 	private baseTokenAddress: Address;
+	private routerAbi;
 
 	constructor(walletService: WalletService) {
 		this.walletService = walletService;
-		this.routerAddress = AGENT_ROUTER_ADDRESS as Address;
-		this.baseTokenAddress = BASE_TOKEN_ADDRESS as Address;
+		this.routerAddress = (
+			process.env.ATP_USE_DEV ? DEV_AGENT_ROUTER_ADDRESS : AGENT_ROUTER_ADDRESS
+		) as Address;
+		this.baseTokenAddress = (
+			process.env.ATP_USE_DEV ? DEV_BASE_TOKEN_ADDRESS : BASE_TOKEN_ADDRESS
+		) as Address;
+		this.routerAbi = process.env.ATP_USE_DEV ? DEV_ROUTER_ABI : ROUTER_ABI;
 	}
 
 	async buy({
@@ -37,9 +49,11 @@ export class SwapService {
 		// Execute buy
 		const buyTx = await walletClient.writeContract({
 			address: this.routerAddress,
-			abi: ROUTER_ABI,
+			abi: this.routerAbi,
 			functionName: "buy",
-			args: [tokenContract, amountInWei, 0n],
+			args: process.env.ATP_USE_DEV
+				? [tokenContract, amountInWei]
+				: [tokenContract, amountInWei, 0n],
 			chain: fraxtal,
 			account: walletClient.account,
 		});
@@ -69,9 +83,11 @@ export class SwapService {
 		// Execute sell
 		const sellTx = await walletClient.writeContract({
 			address: this.routerAddress,
-			abi: ROUTER_ABI,
+			abi: this.routerAbi,
 			functionName: "sell",
-			args: [tokenContract, amountInWei, 0n],
+			args: process.env.ATP_USE_DEV
+				? [tokenContract, amountInWei]
+				: [tokenContract, amountInWei, 0n],
 			chain: fraxtal,
 			account: walletClient.account,
 		});


### PR DESCRIPTION
The following changes were made:

- Added `DEV_API_URLS`, `DEV_AGENT_ROUTER_ADDRESS`, and `DEV_BASE_TOKEN_ADDRESS` constants.
- Updated `AgentPositionsService`, `AgentStatsService`, `GetAgentsService`, `AgentLogsService`, and `SwapService` to use the dev environment URLs and addresses when the `ATP_USE_DEV` environment variable is set.
- Added `DEV_ROUTER_ABI` for the dev environment.
- Updated the `buy` and `sell` functions in `SwapService` to use the correct arguments based on the environment.

These changes allow developers to test the ATP plugin against a development backend and smart contracts.