### PR TITLE
Text correction in atp and hb plugins doc

### DIFF
--- a/apps/docs/src/content/docs/plugins/atp.mdx
+++ b/apps/docs/src/content/docs/plugins/atp.mdx
@@ -43,11 +43,11 @@ Here's a complete example of setting up an agent with the ATP plugin:
 
 ```typescript
 import { AgentBuilder, ModelProviderName } from "@iqai/agent";
-import { createATPPlugin } from "@iqai/plugin-atp";
+import { createAtpPlugin } from "@iqai/plugin-atp";
 
 async function main() {
   // Initialize ATP plugin
- const atpPlugin = await createATPPlugin({
+ const atpPlugin = await createAtpPlugin({
     walletPrivateKey: process.env.WALLET_PRIVATE_KEY,
   });
 
@@ -110,7 +110,7 @@ Always implement proper error handling when using the plugin:
 
 ```typescript
 try {
-  const atpPlugin = await createATPPlugin({
+  const atpPlugin = await createAtpPlugin({
     walletPrivateKey: process.env.WALLET_PRIVATE_KEY,
   });
 } catch (error) {

--- a/apps/docs/src/content/docs/plugins/heartbeat.mdx
+++ b/apps/docs/src/content/docs/plugins/heartbeat.mdx
@@ -48,7 +48,7 @@ async function main() {
       clients: [
         {
           type: "telegram",
-          chatId: process.env.TELEGRAM_CHAT_ID
+          chatId: process.env.TELEGRAM_CHAT_ID as string
         }
       ]
     }


### PR DESCRIPTION
I notice `createAtpPlugin` was misssplled as `createATPPlugin`
also added `as string` to `chatId: process.env.TELEGRAM_CHAT_ID`